### PR TITLE
Properly encode the final URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ module.exports = class Lyrics extends Plugin {
             }
 
             // the response body as JSON
-            const data = await get(base + args).then(res => JSON.parse(res.body));
+            const data = await get(encodeURI(base + args)).then(res => JSON.parse(res.body));
 
             // response had no ``data`` key, which means the query returned nothing
             if (!data.data) {


### PR DESCRIPTION
If a song contains unusual characters (in my case they were Japanese), lyrics will fail to fetch because characters are not escaped properly (see screenshot below)

![image](https://user-images.githubusercontent.com/48173186/111313653-0b617300-867a-11eb-808b-28bf5a4305d0.png)
This PR aims to fix that.

Found this issue only after you merged my last PR, sorry for the spam 😄
